### PR TITLE
Implement EventId class with UUID generation and tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,7 @@ ThisBuild / scalaVersion := "3.8.2"
 lazy val root = (project in file("."))
   .settings(
     name := "karena",
-    libraryDependencies += "org.scalafx" %% "scalafx" % "23.0.1-R34"
+    libraryDependencies += "org.scalafx" %% "scalafx" % "23.0.1-R34",
+    libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.19",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % "test"
   )

--- a/src/main/scala/EventId.scala
+++ b/src/main/scala/EventId.scala
@@ -1,10 +1,18 @@
+import java.time.LocalDateTime
 import java.util.UUID
 
 /** Documentation for reference:
- *   https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html **/
+ *   https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html
+ *   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes-- **/
 
 case class EventId(value: UUID)
 
 object EventId:
   def random(): EventId =
     EventId(UUID.randomUUID())
+
+  def fromEventData(title: String, time: LocalDateTime): EventId =
+    val rawString: String = s"$title $time"
+    // println(s"Representative string: \"$rawString\"")
+    val rawBytes: Array[Byte] = rawString.getBytes()
+    EventId(UUID.nameUUIDFromBytes(rawBytes))

--- a/src/main/scala/EventId.scala
+++ b/src/main/scala/EventId.scala
@@ -13,10 +13,10 @@ object EventId:
   def random(): EventId =
     EventId(UUID.randomUUID())
 
-  def fromEventData(title: String, time: LocalDateTime): EventId =
+  def deterministic(title: String, createdAt: LocalDateTime): EventId =
     /** Encode with UTF-8 explicitly to make UUID generation deterministic across environments.
      *  Using getBytes() without a charset would rely on the platform default encoding. **/
-    val rawString: String = s"$title $time"
+    val rawString: String = s"$title $createdAt"
     // println(s"Representative string: \"$rawString\"")
     val rawBytes: Array[Byte] = rawString.getBytes(StandardCharsets.UTF_8)
     EventId(UUID.nameUUIDFromBytes(rawBytes))

--- a/src/main/scala/EventId.scala
+++ b/src/main/scala/EventId.scala
@@ -4,3 +4,7 @@ import java.util.UUID
  *   https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html **/
 
 case class EventId(value: UUID)
+
+object EventId:
+  def random(): EventId =
+    EventId(UUID.randomUUID())

--- a/src/main/scala/EventId.scala
+++ b/src/main/scala/EventId.scala
@@ -1,9 +1,11 @@
+import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 import java.util.UUID
 
 /** Documentation for reference:
  *   https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html
- *   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes-- **/
+ *   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes--
+ *   https://docs.oracle.com/javase/8/docs/api/java/nio/charset/StandardCharsets.html **/
 
 case class EventId(value: UUID)
 
@@ -12,7 +14,9 @@ object EventId:
     EventId(UUID.randomUUID())
 
   def fromEventData(title: String, time: LocalDateTime): EventId =
+    /** Encode with UTF-8 explicitly to make UUID generation deterministic across environments.
+     *  Using getBytes() without a charset would rely on the platform default encoding. **/
     val rawString: String = s"$title $time"
     // println(s"Representative string: \"$rawString\"")
-    val rawBytes: Array[Byte] = rawString.getBytes()
+    val rawBytes: Array[Byte] = rawString.getBytes(StandardCharsets.UTF_8)
     EventId(UUID.nameUUIDFromBytes(rawBytes))

--- a/src/main/scala/EventId.scala
+++ b/src/main/scala/EventId.scala
@@ -1,0 +1,6 @@
+import java.util.UUID
+
+/** Documentation for reference:
+ *   https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html **/
+
+case class EventId(value: UUID)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -38,14 +38,7 @@ object Main extends JFXApp3:
     // Define test data for generating the UUID
     val eventTitle_2: String = "OS2 Sprint 2 Meeting"
     val eventTime_2: LocalDateTime = LocalDateTime.of(2026, 3, 19, 14, 30)
-    // Scala string interpolation:
-    //   https://docs.scala-lang.org/scala3/book/string-interpolation.html
-    val rawString_2: String = s"$eventTitle_2 $eventTime_2"
-    println(s"Representative string: \"$rawString_2\"")
-    // Convert string into byte array required for UUID generation
-    //   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes--
-    val rawBytes_2: Array[Byte] = rawString_2.getBytes()
-    val eventId_2: EventId = EventId(UUID.nameUUIDFromBytes(rawBytes_2))
+    val eventId_2: EventId = EventId.fromEventData(eventTitle_2, eventTime_2)
     println(s"Event ID: $eventId_2")
 
   end start

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -29,7 +29,7 @@ object Main extends JFXApp3:
 
     root.children += rectangle
 
-    val eventId_1: EventId = EventId(UUID.randomUUID())
+    val eventId_1: EventId = EventId.random()
     println(s"Event ID: $eventId_1")
 
   end start

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -5,6 +5,7 @@ import scalafx.scene.shape.Rectangle
 import scalafx.scene.paint.Color.*
 
 import java.time.LocalDateTime
+import java.util.UUID
 
 object Main extends JFXApp3:
 
@@ -41,6 +42,11 @@ object Main extends JFXApp3:
     //   https://docs.scala-lang.org/scala3/book/string-interpolation.html
     val rawString_2: String = s"$eventTitle_2 $eventTime_2"
     println(s"Representative string: \"$rawString_2\"")
+    // Convert string into byte array required for UUID generation
+    //   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes--
+    val rawBytes_2: Array[Byte] = rawString_2.getBytes()
+    val eventId_2: EventId = EventId(UUID.nameUUIDFromBytes(rawBytes_2))
+    println(s"Event ID: $eventId_2")
 
   end start
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,7 +4,7 @@ import scalafx.scene.layout.Pane
 import scalafx.scene.shape.Rectangle
 import scalafx.scene.paint.Color.*
 
-import java.util.UUID
+import java.time.LocalDateTime
 
 object Main extends JFXApp3:
 
@@ -29,8 +29,18 @@ object Main extends JFXApp3:
 
     root.children += rectangle
 
+    /** Random UUID **/
     val eventId_1: EventId = EventId.random()
     println(s"Event ID: $eventId_1")
+
+    /** Deterministic UUID **/
+    // Define test data for generating the UUID
+    val eventTitle_2: String = "OS2 Sprint 2 Meeting"
+    val eventTime_2: LocalDateTime = LocalDateTime.of(2026, 3, 19, 14, 30)
+    // Scala string interpolation:
+    //   https://docs.scala-lang.org/scala3/book/string-interpolation.html
+    val rawString_2: String = s"$eventTitle_2 $eventTime_2"
+    println(s"Representative string: \"$rawString_2\"")
 
   end start
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -2,7 +2,9 @@ import scalafx.application.JFXApp3
 import scalafx.scene.Scene
 import scalafx.scene.layout.Pane
 import scalafx.scene.shape.Rectangle
-import scalafx.scene.paint.Color._
+import scalafx.scene.paint.Color.*
+
+import java.util.UUID
 
 object Main extends JFXApp3:
 
@@ -26,6 +28,9 @@ object Main extends JFXApp3:
       fill = Blue
 
     root.children += rectangle
+
+    val eventId_1: EventId = EventId(UUID.randomUUID())
+    println(s"Event ID: $eventId_1")
 
   end start
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -37,7 +37,7 @@ object Main extends JFXApp3:
     /** Deterministic UUID **/
     val eventTitle_2: String = "OS2 Sprint 2 Meeting"
     val eventTime_2: LocalDateTime = LocalDateTime.of(2026, 3, 19, 14, 30)
-    val eventId_2: EventId = EventId.fromEventData(eventTitle_2, eventTime_2)
+    val eventId_2: EventId = EventId.deterministic(eventTitle_2, eventTime_2)
     println(s"Event ID: $eventId_2")
 
   end start

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -35,7 +35,6 @@ object Main extends JFXApp3:
     println(s"Event ID: $eventId_1")
 
     /** Deterministic UUID **/
-    // Define test data for generating the UUID
     val eventTitle_2: String = "OS2 Sprint 2 Meeting"
     val eventTime_2: LocalDateTime = LocalDateTime.of(2026, 3, 19, 14, 30)
     val eventId_2: EventId = EventId.fromEventData(eventTitle_2, eventTime_2)

--- a/src/test/scala/EventIdTest.scala
+++ b/src/test/scala/EventIdTest.scala
@@ -6,37 +6,48 @@ import java.util.UUID
 
 class EventIdTest extends AnyFlatSpec {
 
-  "Same event data" must "produce the same EventId" in {
+  "Same title and creation time" should "produce the same EventId" in {
     val title = "OS2 Sprint 2 Meeting"
-    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+    val createdAt = LocalDateTime.of(2026, 3, 19, 14, 30)
 
-    val id1 = EventId.fromEventData(title, time)
-    val id2 = EventId.fromEventData(title, time)
+    val id1 = EventId.deterministic(title, createdAt)
+    val id2 = EventId.deterministic(title, createdAt)
 
     assert(id1 == id2)
   }
 
-  "Different event data" should "produce a different EventId" in {
-    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+  "Different title" should "produce a different EventId" in {
+    val createdAt = LocalDateTime.of(2026, 3, 19, 14, 30)
 
-    val id1 = EventId.fromEventData("OS2 Sprint 2 Meeting", time)
-    val id2 = EventId.fromEventData("OS2 Sprint 3 Meeting", time)
+    val id1 = EventId.deterministic("OS2 Sprint 2 Meeting", createdAt)
+    val id2 = EventId.deterministic("OS2 Sprint 3 Meeting", createdAt)
 
     assert(id1 != id2)
   }
 
-  "Known event data" should "produce the expected UUID" in {
+  "Different creation time" should "produce a different EventId" in {
     val title = "OS2 Sprint 2 Meeting"
-    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+    val createdAt1 = LocalDateTime.of(2026, 3, 19, 14, 30)
+    val createdAt2 = LocalDateTime.of(2026, 3, 19, 16, 30)
+
+    val id1 = EventId.deterministic(title, createdAt1)
+    val id2 = EventId.deterministic(title, createdAt2)
+
+    assert(id1 != id2)
+  }
+
+  "Known title and creation time" should "produce the expected UUID" in {
+    val title = "OS2 Sprint 2 Meeting"
+    val createdAt = LocalDateTime.of(2026, 3, 19, 14, 30)
 
     val expected = EventId(UUID.fromString("75ff0a2f-17e2-383b-9531-9d64f4add6b2"))
-    val actual = EventId.fromEventData(title, time)
+    val actual = EventId.deterministic(title, createdAt)
 
     assert(actual == expected)
   }
 
   "EventId generation" must "not throw exceptions for titles with unusual Unicode characters" in {
-    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+    val createdAt = LocalDateTime.of(2026, 3, 19, 14, 30)
 
     // Some unusual but valid Unicode titles to check that ID generation does not crash
     val titles = Seq(
@@ -53,7 +64,7 @@ class EventIdTest extends AnyFlatSpec {
     // https://www.scalatest.org/user_guide/using_matchers#expectedExceptions
     titles.foreach { title =>
       noException should be thrownBy {
-        EventId.fromEventData(title, time)
+        EventId.deterministic(title, createdAt)
       }
     }
   }

--- a/src/test/scala/EventIdTest.scala
+++ b/src/test/scala/EventIdTest.scala
@@ -1,0 +1,24 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import java.time.LocalDateTime
+
+class EventIdTest extends AnyFlatSpec {
+
+  "Same event data" must "produce the same EventId" in {
+    val title = "OS2 Sprint 2 Meeting"
+    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+
+    val id1 = EventId.fromEventData(title, time)
+    val id2 = EventId.fromEventData(title, time)
+
+    assert(id1 == id2)
+  }
+
+  "Different event data" should "produce a different EventId" in {
+    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+
+    val id1 = EventId.fromEventData("OS2 Sprint 2 Meeting", time)
+    val id2 = EventId.fromEventData("OS2 Sprint 3 Meeting", time)
+
+    assert(id1 != id2)
+  }
+}

--- a/src/test/scala/EventIdTest.scala
+++ b/src/test/scala/EventIdTest.scala
@@ -1,5 +1,6 @@
 import org.scalatest.flatspec.AnyFlatSpec
 import java.time.LocalDateTime
+import java.util.UUID
 
 class EventIdTest extends AnyFlatSpec {
 
@@ -21,4 +22,15 @@ class EventIdTest extends AnyFlatSpec {
 
     assert(id1 != id2)
   }
+
+  "Known event data" should "produce the expected UUID" in {
+    val title = "OS2 Sprint 2 Meeting"
+    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+
+    val expected = EventId(UUID.fromString("75ff0a2f-17e2-383b-9531-9d64f4add6b2"))
+    val actual = EventId.fromEventData(title, time)
+
+    assert(actual == expected)
+  }
+
 }

--- a/src/test/scala/EventIdTest.scala
+++ b/src/test/scala/EventIdTest.scala
@@ -1,4 +1,6 @@
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.*
+
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -33,4 +35,26 @@ class EventIdTest extends AnyFlatSpec {
     assert(actual == expected)
   }
 
+  "EventId generation" must "not throw exceptions for titles with unusual Unicode characters" in {
+    val time = LocalDateTime.of(2026, 3, 19, 14, 30)
+
+    // Some unusual but valid Unicode titles to check that ID generation does not crash
+    val titles = Seq(
+      "Sprint \"review\" and 'retro'",
+      "Sprint “review” and ‘retro’",
+      "Team sync 🙂 🚀",
+      "Tapaaminen äöå",
+      "Проект встреча",
+      "こんにちは会議",
+      "会议安排",
+      "회의 일정"
+    )
+
+    // https://www.scalatest.org/user_guide/using_matchers#expectedExceptions
+    titles.foreach { title =>
+      noException should be thrownBy {
+        EventId.fromEventData(title, time)
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR introduces an `EventId` value type as a wrapper around `UUID` and adds support for two ways of creating event IDs:

* `EventId.random()` for randomly generated IDs
* `EventId.deterministic(title, createdAt)` for deterministic IDs based on event title and creation time

It also adds the first automated tests for `EventId` generation using ScalaTest.

## Changes

* add ScalaTest and Scalactic dependencies to `build.sbt`
* add `EventId` as a domain wrapper around `UUID`
* add `random()` factory method for generating random IDs
* add `deterministic(title, createdAt)` factory method for deterministic ID generation
* encode the representative string with UTF-8 explicitly before calling `UUID.nameUUIDFromBytes(...)`
* add basic example usage of random and deterministic IDs in `Main.scala`
* add `EventIdTest.scala` with tests for:
  * deterministic generation from the same input
  * different IDs for different titles
  * different IDs for different creation times
  * expected UUID output for known input
  * Unicode robustness for titles with unusual characters

## Motivation

The goal of this PR is to introduce a small but explicit domain type for event identifiers instead of using raw `UUID` values directly everywhere.

The deterministic constructor is intended to use **title + creation time semantics**, so the generated ID is reproducible for the same input. UTF-8 encoding is specified explicitly to avoid relying on platform default encoding and to keep the generated UUID stable across environments.

## Notes

* `Main.scala` currently includes simple print-based examples just to demonstrate usage.
* The current deterministic strategy is based on a representative string built from `title` and `createdAt`. This is sufficient for now, but the format can be refined later if needed.

## Testing

Added unit tests covering:

* same input -> same `EventId`
* different title -> different `EventId`
* different creation time -> different `EventId`
* known input -> expected UUID
* unusual Unicode titles do not throw exceptions
